### PR TITLE
Revert change to .gitmodules and update submodule pointer for ccpp-physics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = gsl/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NOAA-GSL/ccpp-physics
-	#branch = gsl/develop
-	url = https://github.com/tanyasmirnova/ccpp-physics
-	branch = gsl_dev_11aug21_lake
+	url = https://github.com/NOAA-GSL/ccpp-physics
+	branch = gsl/develop


### PR DESCRIPTION
@tanyasmirnova please merge this PR. All it does is to revert the change to `.gitmodules` and to update submodule pointer for ccpp-physics following the merge of https://github.com/NOAA-GSL/ccpp-physics/pull/103. Thanks!